### PR TITLE
Move non babel config into its own key

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ Customize the babel options:
 
 ```javascript
   requirejs.config({
+    es6: {
+      fileExtension: '.js' // put in .jsx for JSX transformation
+    },
     babel: {
       blacklist: [],
       nonStandard: true,
-      fileExtension: 'js', // It is not official babel-option
       ...
     }
   });

--- a/es6.js
+++ b/es6.js
@@ -38,7 +38,8 @@ define(['babel', 'module'], function(babel, _module) {
         load: function(name, req, onload, config) {
 
             var babelOptions = config.babel || {},
-                fileExtension = babelOptions.fileExtension || '.js',
+                pluginOptions = config.es6 || {},
+                fileExtension = pluginOptions.fileExtension || '.js',
                 url = req.toUrl(name + fileExtension);
 
             var defaults = {
@@ -49,9 +50,6 @@ define(['babel', 'module'], function(babel, _module) {
             for (var key in defaults) {
                 babelOptions[key] = defaults[key];
             }
-
-            // Delete unsupported option
-            delete babelOptions.fileExtension;
 
             fetchText(url, function(text) {
                 try {


### PR DESCRIPTION
When deleting the `babelOptions.fileExtension` key you are directly removing it from the configuration object. Therefore the fileExtension configuration will not work for subsequent requirements.
