### PR TITLE
empty path fix

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -42,6 +42,12 @@ define(['babel', 'module'], function(babel, _module) {
                 fileExtension = pluginOptions.fileExtension || '.js',
                 url = req.toUrl(name + fileExtension);
 
+            // Do not load if it is an empty: url
+            if (url.indexOf('empty:') === 0) {
+                onload();
+                return;
+            }
+
             var defaults = {
                 sourceMaps: config.isBuild ? false : 'inline',
                 sourceFileName: name


### PR DESCRIPTION
"empty:" path support

Take a look at the requirejs text plugin for example...

https://github.com/requirejs/text/blob/master/text.js line 197- 200
